### PR TITLE
fix(emacsql-parse): Respect new `rx`.

### DIFF
--- a/emacsql-sqlite3.el
+++ b/emacsql-sqlite3.el
@@ -181,7 +181,7 @@ each arg will be quoted first."
 (cl-defmethod emacsql-parse ((conn emacsql-sqlite3-connection))
   (with-current-buffer (emacsql-buffer conn)
     (goto-char (point-min))
-    (if (looking-at (rx "Error: " (group (1+ char)) eol))
+    (if (looking-at (rx "Error: " (group (1+ any)) eol))
         (signal 'emacsql-error (list (match-string 1)))
       (cl-macrolet ((sexps-in-line! ()
                       `(cl-loop until (looking-at "\n")


### PR DESCRIPTION
According to this thread, `(rx char)` is misomer, use `(rx any)` instead.

https://lists.gnu.org/archive/html/bug-gnu-emacs/2019-11/msg00849.html


----

#