### PR TITLE
Avoid a dependency on the ~/.sqliterc config file

### DIFF
--- a/emacsql-sqlite3.el
+++ b/emacsql-sqlite3.el
@@ -170,6 +170,8 @@ each arg will be quoted first."
                            "--list" "--separator" " "
                            ;; Obviously
                            "--nullvalue" "nil"
+                           ;; Don't return column headings
+                           "--noheader"
                            ,@fullfile)
                 :buffer (generate-new-buffer " *emacsql sqlite*")
                 :noquery t


### PR DESCRIPTION
If the following line appears in ~/.sqliterc:

    .headers on

Then this:

    (setq db (emacsql-sqlite3 "/tmp/foo.sqlite3"))
    (emacsql db "CREATE TABLE foo (spam integer, eggs text)")
    (emacsql db "INSERT INTO foo (spam, eggs) VALUES (1, 'Hello')")
    (emacsql db "SELECT * FROM foo")

Would return:

    ((spam eggs) (1 Hello))

With this change, it returns:

    ((1 Hello))

which is the same as the return value when the ~/.sqliterc file does not exist.