### PR TITLE
add emacsql-sqlite3-init-file

### DIFF
--- a/emacsql-sqlite3.el
+++ b/emacsql-sqlite3.el
@@ -114,6 +114,13 @@ https://www.sqlite.org/lang_keywords.html")
   :group 'emacsql-sqlite3
   :type 'file)
 
+(defcustom emacsql-sqlite3-init-file nil
+  "The path to the init file.
+The init file can contain a mix of SQL statements and meta-commands.
+When non-nil, it is passed to the init flag when starting the sqlite3 process."
+  :group 'emacsql-sqlite3
+  :type 'file)
+
 (defclass emacsql-sqlite3-connection (emacsql-connection)
   ((file :initarg :file
          :type (or null string)
@@ -172,7 +179,10 @@ each arg will be quoted first."
                            "--nullvalue" "nil"
                            ;; Don't return column headings
                            "--noheader"
-                           ,@fullfile)
+                           ;; pass init file if set
+                           ,@(when emacsql-sqlite3-init-file
+                               `("--init" ,emacsql-sqlite3-init-file)
+                           ,@fullfile))
                 :buffer (generate-new-buffer " *emacsql sqlite*")
                 :noquery t
                 :connection-type 'pipe

--- a/emacsql-sqlite3.el
+++ b/emacsql-sqlite3.el
@@ -114,12 +114,7 @@ https://www.sqlite.org/lang_keywords.html")
   :group 'emacsql-sqlite3
   :type 'file)
 
-(defcustom emacsql-sqlite3-init-file
-  (pcase system-type
-    ((or `darwin `gnu `gnu/linux `gnu/kfreebsd)
-     "/dev/null")
-    ((or `ms-dos `windows-nt `cygwin)
-     "nul"))
+(defcustom emacsql-sqlite3-init-file null-device
   "The path to the init file.
 The init file can contain a mix of SQL statements and meta-commands.
 When non-nil, it is passed to the init flag when starting the sqlite3 process."

--- a/emacsql-sqlite3.el
+++ b/emacsql-sqlite3.el
@@ -114,7 +114,12 @@ https://www.sqlite.org/lang_keywords.html")
   :group 'emacsql-sqlite3
   :type 'file)
 
-(defcustom emacsql-sqlite3-init-file nil
+(defcustom emacsql-sqlite3-init-file
+  (pcase system-type
+    ((or `darwin `gnu `gnu/linux `gnu/kfreebsd)
+     "/dev/null")
+    ((or `ms-dos `windows-nt `cygwin)
+     "nul"))
   "The path to the init file.
 The init file can contain a mix of SQL statements and meta-commands.
 When non-nil, it is passed to the init flag when starting the sqlite3 process."
@@ -181,8 +186,8 @@ each arg will be quoted first."
                            "--noheader"
                            ;; pass init file if set
                            ,@(when emacsql-sqlite3-init-file
-                               `("--init" ,emacsql-sqlite3-init-file)
-                           ,@fullfile))
+                               `("--init" ,emacsql-sqlite3-init-file))
+                           ,@fullfile)
                 :buffer (generate-new-buffer " *emacsql sqlite*")
                 :noquery t
                 :connection-type 'pipe


### PR DESCRIPTION
When set, `emacsql-sqlite3-init-file` will be passed to the sqlite3 process with the `--init` flag.

Org-roam uses `emacsql-sqlite3`, and some users turn on things in their `~/.sqliterc` that breaks some functionality (see https://github.com/org-roam/org-roam/issues/1080)

We need to find a way to turn off all user customizations for the sqlite3 process, and the `--init` file is one way.