### PR TITLE
bump version to 1.0.2

### DIFF
--- a/emacsql-sqlite3.el
+++ b/emacsql-sqlite3.el
@@ -4,7 +4,7 @@
 
 ;; Author: Zhu Zihao <all_but_last@163.com>
 ;; URL: https://github.com/cireu/emacsql-sqlite3
-;; Version: 1.0.1
+;; Version: 1.0.2
 ;; Package-Requires: ((emacs "26.1") (emacsql "3.0.0"))
 ;; Keywords: extensions
 


### PR DESCRIPTION
While the tag has been bumped to 1.0.2, the package version in the el file is still at 1.0.1.